### PR TITLE
Improve CI performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - uses: chrisdickinson/setup-yq@v1.0.1
+        with:
+          yq-version: v4.25.3
+
       - name: Vet
         run: go vet ./...
 
@@ -45,6 +49,7 @@ jobs:
           cd ..
           curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/v2.4.6/scripts/bootstrap.sh | bash -s
           export FABRIC_SAMPLES_DIR=$(pwd)/fabric-samples/
+          yq -i '.Orderer.BatchTimeout = "10ms"' $(pwd)/fabric-samples/test-network/configtx/configtx.yaml
           cd perun-fabric/
           ./scripts/deployCC.sh
           go test -timeout 700s ./... -p 1


### PR DESCRIPTION
This PR adapts the CI (via modifying its yml config file) s.t. the orderer of the [fabric-samples test network](https://github.com/hyperledger/fabric-samples/tree/main/test-network) processes our interaction with the chaincode faster. This leads to a noticeable reduction in CI running time (from currently ~10min to ~4min).

_Note that half of the remaining running time (~2min) is used for the deployment of the chaincode. The other half is needed for downloading & setting up the test chain._