### PR TITLE
Remove noAsset

### DIFF
--- a/channel/backend.go
+++ b/channel/backend.go
@@ -67,7 +67,7 @@ func (Backend) NewAsset() channel.Asset {
 	return asset{}
 }
 
-// NewRandomAsset returns a new fabric asset.
+// NewRandomAsset returns a new Fabric asset.
 func (b Backend) NewRandomAsset(*rand.Rand) channel.Asset {
 	return asset{}
 }

--- a/channel/backend.go
+++ b/channel/backend.go
@@ -62,7 +62,7 @@ func (Backend) Verify(addr wallet.Address, state *channel.State, sig wallet.Sig)
 	return wallet.VerifySignature(buf.Bytes(), sig, addr)
 }
 
-// NewAsset returns a new fabric asset.
+// NewAsset returns a new Fabric asset.
 func (Backend) NewAsset() channel.Asset {
 	return asset{}
 }

--- a/channel/backend.go
+++ b/channel/backend.go
@@ -64,24 +64,10 @@ func (Backend) Verify(addr wallet.Address, state *channel.State, sig wallet.Sig)
 
 // NewAsset returns an empty noAsset.
 func (Backend) NewAsset() channel.Asset {
-	return noAsset{}
+	return asset{}
 }
 
 // NewRandomAsset returns an empty noAsset.
 func (b Backend) NewRandomAsset(*rand.Rand) channel.Asset {
-	return noAsset{}
-}
-
-type noAsset struct{}
-
-// MarshalBinary - noop.
-func (noAsset) MarshalBinary() ([]byte, error) { return nil, nil }
-
-// UnmarshalBinary - noop.
-func (noAsset) UnmarshalBinary([]byte) error { return nil }
-
-// Equal returns true iff the other asset is also a noAsset.
-func (noAsset) Equal(other channel.Asset) bool {
-	_, ok := other.(noAsset)
-	return ok
+	return asset{}
 }

--- a/channel/backend.go
+++ b/channel/backend.go
@@ -62,12 +62,14 @@ func (Backend) Verify(addr wallet.Address, state *channel.State, sig wallet.Sig)
 	return wallet.VerifySignature(buf.Bytes(), sig, addr)
 }
 
-// NewAsset returns an empty noAsset.
+// NewAsset returns a fabric asset.
+// Does not contain any fields since there is only one asset per chain.
 func (Backend) NewAsset() channel.Asset {
 	return asset{}
 }
 
-// NewRandomAsset returns an empty noAsset.
+// NewRandomAsset returns a fabric asset.
+// Does not contain any fields since there is only one asset per chain.
 func (b Backend) NewRandomAsset(*rand.Rand) channel.Asset {
 	return asset{}
 }

--- a/channel/backend.go
+++ b/channel/backend.go
@@ -62,14 +62,12 @@ func (Backend) Verify(addr wallet.Address, state *channel.State, sig wallet.Sig)
 	return wallet.VerifySignature(buf.Bytes(), sig, addr)
 }
 
-// NewAsset returns a fabric asset.
-// Does not contain any fields since there is only one asset per chain.
+// NewAsset returns a new fabric asset.
 func (Backend) NewAsset() channel.Asset {
 	return asset{}
 }
 
-// NewRandomAsset returns a fabric asset.
-// Does not contain any fields since there is only one asset per chain.
+// NewRandomAsset returns a new fabric asset.
 func (b Backend) NewRandomAsset(*rand.Rand) channel.Asset {
 	return asset{}
 }


### PR DESCRIPTION
`noAsset` is redundant.

It leads to confusion if a channel is created with the normal fabric asset `channel.Asset` on the one side. The other peer might interpret the asset during decoding as `noAsset`. This results in only the proposer being able to send valid transactions as the other peer will send its transaction with a mismatching asset.

Proposal: Remove noAsset